### PR TITLE
suggested metrics for data discovery

### DIFF
--- a/ds_capability/components/discovery.py
+++ b/ds_capability/components/discovery.py
@@ -300,7 +300,6 @@ class DataDiscovery(object):
                 record.append([n, 'measure', 'temporal' if pa.types.is_temporal(c.type) else 'continuous'])
                 record.append([n, 'nulls', c.null_count])
                 record.append([n, 'valid', pc.sum(c.is_valid()).as_py()])
-                record.append([n, 'value_counts', vc])
                 record.append([n, 'null_proportions', (c.null_count/vc)])
                 record.append([n, 'valid_proportions', ((pc.sum(c.is_valid()).as_py())/vc)])
                 unique_count =  sum(1 for _, count in collections.Counter(c.to_pylist()).items() if count == 1)


### PR DESCRIPTION
ref: https://docs.open-metadata.org/v1.2.x/connectors/ingestion/workflows/profiler/metrics

null_proportions: It shows the ratio of null values vs. the total number of values in a column.
valid_proportions: Percentage of values in this column vs. the Row Count.
unique: The number of unique values in a column, those that appear only once. E.g., [1, 2, 2, 3, 3, 4] => [1, 4] => count = 2.
distinct: The number of different items in a column. E.g., [1, 2, 2, 3, 3, 4] => [1, 2, 3, 4] => count = 4.
unique_proportions: Unique Count / Values Count
distinct_proportions:  Distinct Count / Values Count